### PR TITLE
feat: 게시물 상세 조회 API 완료

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,11 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
 };

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,7 +21,7 @@ import { StatisticsModule } from './feature/statistics/statistics.module';
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
       entities: [User, Post, Hashtag],
-      synchronize: true, // 개발환경(DB 만들고 false로 변경하기)
+      synchronize: false, // 개발환경(DB 만들고 false로 변경하기)
       logging: true,
       keepConnectionAlive: true,
     }),

--- a/src/entity/hashtag.entity.ts
+++ b/src/entity/hashtag.entity.ts
@@ -13,6 +13,9 @@ export class Hashtag {
   @PrimaryGeneratedColumn()
   id!: number;
 
+  @Column({ name: 'post_id' })
+  postId: number;
+
   @Column()
   hashtag!: string;
 
@@ -21,5 +24,5 @@ export class Hashtag {
 
   @ManyToOne(() => Post, (post) => post.hashtags)
   @JoinColumn({ name: 'post_id' })
-  post: Post;
+  post?: Post;
 }

--- a/src/entity/hashtag.entity.ts
+++ b/src/entity/hashtag.entity.ts
@@ -13,9 +13,6 @@ export class Hashtag {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column({ name: 'post_id' })
-  postId: number;
-
   @Column()
   hashtag!: string;
 

--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -24,13 +24,13 @@ export class Post {
   content!: string;
 
   @Column({ name: 'view_count' })
-  viewCount!: string;
+  viewCount!: number;
 
   @Column({ name: 'like_count' })
-  likeCount!: string;
+  likeCount!: number;
 
   @Column({ name: 'share_count' })
-  shareCount!: string;
+  shareCount!: number;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
@@ -39,5 +39,5 @@ export class Post {
   updatedAt!: Date;
 
   @OneToMany(() => Hashtag, (hashtag) => hashtag.post)
-  hashtags: Hashtag[];
+  hashtags?: Hashtag[];
 }

--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -39,5 +39,5 @@ export class Post {
   updatedAt!: Date;
 
   @OneToMany(() => Hashtag, (hashtag) => hashtag.post)
-  hashtags?: Hashtag[];
+  hashtags!: Hashtag[];
 }

--- a/src/error/error.enum.ts
+++ b/src/error/error.enum.ts
@@ -1,0 +1,3 @@
+export enum ErrorMessage {
+  postNotFound = '게시글을 찾을 수 없습니다.',
+}

--- a/src/feature/custom/apiResult.ts
+++ b/src/feature/custom/apiResult.ts
@@ -1,0 +1,13 @@
+import { ErrorMessage } from 'src/error/error.enum';
+
+type SuccessResult<T> = {
+  success: true;
+  data: T;
+};
+
+type FailResult = {
+  success: false;
+  message: ErrorMessage;
+};
+
+export type ApiResult<T> = SuccessResult<T> | FailResult;

--- a/src/feature/post/post.app.module.ts
+++ b/src/feature/post/post.app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PostController } from './post.controller';
 import { PostService } from './post.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Post } from 'src/entity/post.entity';
 
 @Module({
-  imports: [],
+  imports: [TypeOrmModule.forFeature([Post])],
   providers: [PostService],
   controllers: [PostController],
 })

--- a/src/feature/post/post.controller.ts
+++ b/src/feature/post/post.controller.ts
@@ -1,6 +1,30 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Post } from 'src/entity/post.entity';
+import { PostService } from './post.service';
+import { ApiResult } from '../custom/apiResult';
+import { ErrorMessage } from 'src/error/error.enum';
 
-@Controller()
+@Controller({
+  path: '/posts',
+})
 export class PostController {
-  constructor() {}
+  constructor(private readonly postService: PostService) {}
+
+  @Get('/:id')
+  async getPostAndAddViewCountById(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<ApiResult<Post>> {
+    const post = await this.postService.getPostWithHasgtagById(id);
+    if (!post) {
+      return {
+        success: false,
+        message: ErrorMessage.postNotFound,
+      };
+    }
+
+    return {
+      success: true,
+      data: await this.postService.getPostAndAddViewCountById(post),
+    };
+  }
 }

--- a/src/feature/post/post.controller.ts
+++ b/src/feature/post/post.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  Param,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { Post } from 'src/entity/post.entity';
 import { PostService } from './post.service';
 import { ApiResult } from '../custom/apiResult';
@@ -16,10 +22,7 @@ export class PostController {
   ): Promise<ApiResult<Post>> {
     const post = await this.postService.getPostWithHasgtagById(id);
     if (!post) {
-      return {
-        success: false,
-        message: ErrorMessage.postNotFound,
-      };
+      throw new HttpException(ErrorMessage.postNotFound, 404);
     }
 
     return {

--- a/src/feature/post/post.service.ts
+++ b/src/feature/post/post.service.ts
@@ -1,6 +1,27 @@
 import { Injectable } from '@nestjs/common';
+import { Post } from 'src/entity/post.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class PostService {
-  constructor() {}
+  constructor(
+    @InjectRepository(Post) private readonly postRepository: Repository<Post>,
+  ) {}
+
+  getPostWithHasgtagById(id: number): Promise<Post> {
+    return this.postRepository
+      .createQueryBuilder('posts')
+      .leftJoinAndSelect('posts.hashtags', 'hashtags')
+      .where('posts.id = :id', { id })
+      .getOne();
+  }
+
+  async getPostAndAddViewCountById(post: Post): Promise<Post> {
+    const addViewCountByPost = await this.postRepository.save({
+      ...post,
+      viewCount: post.viewCount + 1,
+    });
+    return addViewCountByPost;
+  }
 }


### PR DESCRIPTION
## 1-통계
<br>

## 💡 변경 이유

<br>

## 🔑 주요 변경사항
### 1. 게시물 상세 API 완료
- **Controller에서 postId가 없을 경우 예외처리**
  -  Service까지 넘어갈 필요는 없어보여서 Controller에서 예외 발생시 바로 리턴 합니다.
- **ApiResult : 타입 제네릭 생성**
  - 성공과 실패의 반환값을 통일성있게 작성하고 싶었습니다.
  - custom 폴더 생성하여 apiResult.ts 파일안에 추가해놨습니다.
- **Repository 사용없이 Service에서 Repository 주입하여 사용**
  - 이건 일요일에 결정되면 변경하도록 하겠습니다. 
- **Test Code 분리**
  - 해당 브랜치에 Test Code 없습니다! Test Code 분리해서 작업할께요. 시간을 잡아먹고 있어서요 😅
- **.eslintrc.js 개행 설정 값 변경**
  - 제가 사용하고 있는 VSCODE에서 개행 관련해서 빨간 밑줄 오류가 전체 파일에 생겨버려서 추가한 값 입니다!
  - CRLF / LF <- 요거 관련 문제인데 파일 전체를 변경해버리면 안 될 것 같아서 설정 값으로 넣었습니다.
- **posts entity에 postId 추가**
  - 아래 이미지처럼 해시태그 안에 postId가 없이 불러와져서 추가해놨습니다!
![예시 이미지](https://github.com/Wanted-Pre-Onboarding-Team-E/social-media-integration-feed/assets/83870420/8c74d862-5fa7-4767-b134-a3b7315060cd)
<br>

## 📷 테스트 결과
