### PR TITLE
posts와 statistics에 hashtag 기본값 주기

### DIFF
--- a/src/feature/post/post.controller.ts
+++ b/src/feature/post/post.controller.ts
@@ -1,3 +1,23 @@
+
+import { Controller, Get, Query, ValidationPipe, Param, Patch } from '@nestjs/common';
+import { PostService } from './post.service';
+import { QueryPostsDto } from './dto/queryPost.dto';
+import { PostType } from 'src/enum/postType.enum';
+
+@Controller('posts')
+export class PostController {
+  constructor(private postService: PostService) {}
+
+
+  @Patch(':postId/like/:type')
+  async incrementPostLikeCount(
+    @Param('type') type: PostType,
+    @Param('postId') postId: number,
+  ) {
+    return await this.postService.incrementPostLikeCount(type, postId);
+  @Get()
+  async getPosts(@Query(ValidationPipe) queryPostsDto: QueryPostsDto) {
+    return await this.postService.getPosts(queryPostsDto);
 import {
   Controller,
   Get,
@@ -6,9 +26,6 @@ import {
   ParseIntPipe,
   Patch,
   UseGuards,
-  Query,
-  ValidationPipe,
-  Req,
 } from '@nestjs/common';
 import { Post } from 'src/entity/post.entity';
 import { PostService } from './post.service';
@@ -18,7 +35,6 @@ import { HttpStatusCode } from 'src/enum/httpStatusCode.enum';
 import { PostType } from 'src/enum/postType.enum';
 import { PostTypeValidationPipe } from '../pipe/postTypeValidation.pipe';
 import { JwtAuthGuard } from '../../auth/guard/jwtAuth.guard';
-import { QueryPostsDto } from './dto/queryPost.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller({
@@ -31,7 +47,7 @@ export class PostController {
   async getPostAndAddViewCountById(
     @Param('id', ParseIntPipe) id: number,
   ): Promise<ApiResult<Post>> {
-    const post = await this.postService.getPostWithHashtagById(id);
+    const post = await this.postService.getPostWithHasgtagById(id);
     if (!post) {
       throw new HttpException(ErrorMessage.postNotFound, 404);
     }
@@ -47,7 +63,7 @@ export class PostController {
     @Param('id', ParseIntPipe) id: number,
     @Param('type', PostTypeValidationPipe) type: PostType,
   ): Promise<ApiResult<void>> {
-    const post = await this.postService.getPostWithHashtagById(id, type);
+    const post = await this.postService.getPostWithHasgtagById(id, type);
     if (!post) {
       throw new HttpException(
         ErrorMessage.postNotFound,
@@ -60,23 +76,5 @@ export class PostController {
     return {
       success: true,
     };
-  }
-
-  @Patch(':postId/like/:type')
-  async incrementPostLikeCount(
-    @Param('type') type: PostType,
-    @Param('postId') postId: number,
-  ) {
-    return await this.postService.incrementPostLikeCount(type, postId);
-  }
-  @Get()
-  async getPosts(
-    @Query(ValidationPipe) queryPostsDto: QueryPostsDto,
-    @Req() req,
-  ) {
-    if (!queryPostsDto.hashtag) {
-      queryPostsDto.hashtag = req.user.username;
-    }
-    return await this.postService.getPosts(queryPostsDto);
   }
 }

--- a/src/feature/post/post.service.ts
+++ b/src/feature/post/post.service.ts
@@ -1,5 +1,3 @@
-
-import { firstValueFrom } from 'rxjs';
 import { QueryPostsDto } from './dto/queryPost.dto';
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { Post } from 'src/entity/post.entity';
@@ -7,18 +5,16 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PostType } from 'src/enum/postType.enum';
 import { StatisticsDTO } from '../statistics/dto/statistics.dto';
-import { StatisticsValueType } from '../../enum/statisticsValueType.enum';
 import { HttpService } from '@nestjs/axios';
 import { catchError, firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
-
 
 @Injectable()
 export class PostService {
   constructor(
     @InjectRepository(Post)
     private postRepository: Repository<Post>,
-    private httpService: HttpService,
+    private readonly httpService: HttpService,
   ) {}
 
   async incrementPostLikeCount(type: PostType, postId: number) {
@@ -58,6 +54,7 @@ export class PostService {
       default:
         throw new Error('타입이 존재하지 않습니다.');
     }
+  }
 
   async getPosts(queryPostsDto: QueryPostsDto): Promise<Post[]> {
     const query = this.postRepository.createQueryBuilder('post');
@@ -106,12 +103,9 @@ export class PostService {
     query.skip(page * pageCount).take(pageCount);
     const posts = await query.getMany();
     return posts;
+  }
 
-    private readonly httpService: HttpService,
-    @InjectRepository(Post) private readonly postRepository: Repository<Post>,
-  ) {}
-
-  getPostWithHasgtagById(id: number, type?: PostType): Promise<Post> {
+  getPostWithHashtagById(id: number, type?: PostType): Promise<Post> {
     const query = this.postRepository
       .createQueryBuilder('posts')
       .leftJoinAndSelect('posts.hashtags', 'hashtags')
@@ -307,6 +301,5 @@ export class PostService {
       });
 
     return formattedResults;
-
   }
 }

--- a/src/feature/post/post.service.ts
+++ b/src/feature/post/post.service.ts
@@ -1,3 +1,5 @@
+
+import { firstValueFrom } from 'rxjs';
 import { QueryPostsDto } from './dto/queryPost.dto';
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { Post } from 'src/entity/post.entity';
@@ -5,16 +7,18 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PostType } from 'src/enum/postType.enum';
 import { StatisticsDTO } from '../statistics/dto/statistics.dto';
+import { StatisticsValueType } from '../../enum/statisticsValueType.enum';
 import { HttpService } from '@nestjs/axios';
 import { catchError, firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
+
 
 @Injectable()
 export class PostService {
   constructor(
     @InjectRepository(Post)
     private postRepository: Repository<Post>,
-    private readonly httpService: HttpService,
+    private httpService: HttpService,
   ) {}
 
   async incrementPostLikeCount(type: PostType, postId: number) {
@@ -54,7 +58,6 @@ export class PostService {
       default:
         throw new Error('타입이 존재하지 않습니다.');
     }
-  }
 
   async getPosts(queryPostsDto: QueryPostsDto): Promise<Post[]> {
     const query = this.postRepository.createQueryBuilder('post');
@@ -103,9 +106,12 @@ export class PostService {
     query.skip(page * pageCount).take(pageCount);
     const posts = await query.getMany();
     return posts;
-  }
 
-  getPostWithHashtagById(id: number, type?: PostType): Promise<Post> {
+    private readonly httpService: HttpService,
+    @InjectRepository(Post) private readonly postRepository: Repository<Post>,
+  ) {}
+
+  getPostWithHasgtagById(id: number, type?: PostType): Promise<Post> {
     const query = this.postRepository
       .createQueryBuilder('posts')
       .leftJoinAndSelect('posts.hashtags', 'hashtags')
@@ -301,5 +307,6 @@ export class PostService {
       });
 
     return formattedResults;
+
   }
 }

--- a/src/feature/post/post.service.ts
+++ b/src/feature/post/post.service.ts
@@ -1,5 +1,3 @@
-
-import { firstValueFrom } from 'rxjs';
 import { QueryPostsDto } from './dto/queryPost.dto';
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { Post } from 'src/entity/post.entity';
@@ -7,18 +5,16 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PostType } from 'src/enum/postType.enum';
 import { StatisticsDTO } from '../statistics/dto/statistics.dto';
-import { StatisticsValueType } from '../../enum/statisticsValueType.enum';
 import { HttpService } from '@nestjs/axios';
 import { catchError, firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
-
 
 @Injectable()
 export class PostService {
   constructor(
     @InjectRepository(Post)
     private postRepository: Repository<Post>,
-    private httpService: HttpService,
+    private readonly httpService: HttpService,
   ) {}
 
   async incrementPostLikeCount(type: PostType, postId: number) {
@@ -58,6 +54,7 @@ export class PostService {
       default:
         throw new Error('타입이 존재하지 않습니다.');
     }
+  }
 
   async getPosts(queryPostsDto: QueryPostsDto): Promise<Post[]> {
     const query = this.postRepository.createQueryBuilder('post');
@@ -106,12 +103,9 @@ export class PostService {
     query.skip(page * pageCount).take(pageCount);
     const posts = await query.getMany();
     return posts;
+  }
 
-    private readonly httpService: HttpService,
-    @InjectRepository(Post) private readonly postRepository: Repository<Post>,
-  ) {}
-
-  getPostWithHasgtagById(id: number, type?: PostType): Promise<Post> {
+  getPostWithHashtagById(id: number, type?: PostType): Promise<Post> {
     const query = this.postRepository
       .createQueryBuilder('posts')
       .leftJoinAndSelect('posts.hashtags', 'hashtags')
@@ -153,8 +147,8 @@ export class PostService {
       this.httpService.get<Post[]>(getSnsUrl(type)).pipe(
         catchError(async (error: AxiosError) => {
           /*
-          NOTE: 가상의 URL이기 때문에 반드시 에러가 발생합니다. 
-                따라서 이 요청이 status 200 성공 응답을 받았다고 
+          NOTE: 가상의 URL이기 때문에 반드시 에러가 발생합니다.
+                따라서 이 요청이 status 200 성공 응답을 받았다고
                 가정하고 catchError 내부에 작성합니다.
           */
           await this.postRepository.save({
@@ -307,6 +301,5 @@ export class PostService {
       });
 
     return formattedResults;
-
   }
 }

--- a/src/feature/statistics/dto/statistics.dto.ts
+++ b/src/feature/statistics/dto/statistics.dto.ts
@@ -13,17 +13,17 @@ export class StatisticsDTO {
   hashtag?: string;
 
   @IsOptional()
-  @IsEnum
+  @IsEnum(StatisticsValueType)
   value?: StatisticsValueType;
 
   @IsNotEmpty()
   type!: 'date' | 'hour';
 
   @IsOptional()
-  @IsDateString
+  @IsDateString()
   start?: string;
 
   @IsOptional()
-  @IsDateString
+  @IsDateString()
   end?: string;
 }

--- a/src/feature/statistics/dto/statistics.dto.ts
+++ b/src/feature/statistics/dto/statistics.dto.ts
@@ -13,17 +13,14 @@ export class StatisticsDTO {
   hashtag?: string;
 
   @IsOptional()
-  @IsEnum
   value?: StatisticsValueType;
 
   @IsNotEmpty()
   type!: 'date' | 'hour';
 
   @IsOptional()
-  @IsDateString
   start?: string;
 
   @IsOptional()
-  @IsDateString
   end?: string;
 }

--- a/src/feature/statistics/dto/statistics.dto.ts
+++ b/src/feature/statistics/dto/statistics.dto.ts
@@ -13,14 +13,17 @@ export class StatisticsDTO {
   hashtag?: string;
 
   @IsOptional()
+  @IsEnum
   value?: StatisticsValueType;
 
   @IsNotEmpty()
   type!: 'date' | 'hour';
 
   @IsOptional()
+  @IsDateString
   start?: string;
 
   @IsOptional()
+  @IsDateString
   end?: string;
 }

--- a/src/feature/statistics/statistics.controller.ts
+++ b/src/feature/statistics/statistics.controller.ts
@@ -1,18 +1,13 @@
-import { Controller, Get, Query, UseGuards, Req } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { StatisticsService } from './statistics.service';
 import { StatisticsDTO } from './dto/statistics.dto';
-import { JwtAuthGuard } from '../../auth/guard/jwtAuth.guard';
 
-@UseGuards(JwtAuthGuard)
 @Controller('statistics')
 export class StatisticsController {
   constructor(private readonly statisticsService: StatisticsService) {}
 
   @Get()
-  getStatistics(@Query() statisticsDTO: StatisticsDTO, @Req() req) {
-    if (!statisticsDTO.hashtag) {
-      statisticsDTO.hashtag = req.user.username;
-    }
+  getStatistics(@Query() statisticsDTO: StatisticsDTO) {
     if (statisticsDTO.type === 'date') {
       return this.statisticsService.getStatisticsByDate(statisticsDTO);
     }

--- a/src/feature/statistics/statistics.controller.ts
+++ b/src/feature/statistics/statistics.controller.ts
@@ -1,13 +1,18 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards, Req } from '@nestjs/common';
 import { StatisticsService } from './statistics.service';
 import { StatisticsDTO } from './dto/statistics.dto';
+import { JwtAuthGuard } from '../../auth/guard/jwtAuth.guard';
 
+@UseGuards(JwtAuthGuard)
 @Controller('statistics')
 export class StatisticsController {
   constructor(private readonly statisticsService: StatisticsService) {}
 
   @Get()
-  getStatistics(@Query() statisticsDTO: StatisticsDTO) {
+  getStatistics(@Query() statisticsDTO: StatisticsDTO, @Req() req) {
+    if (!statisticsDTO.hashtag) {
+      statisticsDTO.hashtag = req.user.username;
+    }
     if (statisticsDTO.type === 'date') {
       return this.statisticsService.getStatisticsByDate(statisticsDTO);
     }

--- a/src/feature/statistics/statistics.service.ts
+++ b/src/feature/statistics/statistics.service.ts
@@ -8,10 +8,6 @@ export class StatisticsService {
   constructor(private readonly postLib: PostLib) {}
 
   setDefaultValue(statisticsDTO: StatisticsDTO) {
-    if (!statisticsDTO.hashtag) {
-      statisticsDTO.hashtag = '태그';
-    }
-
     if (!statisticsDTO.value) {
       statisticsDTO.value = StatisticsValueType.COUNT;
     }


### PR DESCRIPTION
## 🚀 이슈 번호
#24 디폴트 값 받기
<br>

## 💡 변경 이유
post와 statistics에서 hashtag에 들어오는 값이 없을 때 접속한 사용자의 username을 기본값으로 주도록 변경.
<br>

## 🔑 주요 변경사항
- 컨트롤러에 UseGuard를 붙이기 때문에 hashtag기본값만 controller에서 보내도록 함
```
getStatistics(@Query() statisticsDTO: StatisticsDTO, @Req() req) {
    if (!statisticsDTO.hashtag) {
      statisticsDTO.hashtag = req.user.username;
    }
    ...
  ```
<br>

## 📷 테스트 결과
