### PR TITLE
[#25] test: statistics unit test code 작성

### DIFF
--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -1,4 +1,4 @@
-import { PostType } from 'src/enum/postType.enum';
+import { PostType } from '../enum/postType.enum';
 import {
   Column,
   CreateDateColumn,
@@ -30,7 +30,6 @@ export class Post {
   likeCount!: number;
 
   @Column({ name: 'share_count', default: 0 })
-
   shareCount!: number;
 
   @CreateDateColumn({ name: 'created_at' })

--- a/src/feature/post/post.service.ts
+++ b/src/feature/post/post.service.ts
@@ -1,9 +1,9 @@
 import { QueryPostsDto } from './dto/queryPost.dto';
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
-import { Post } from 'src/entity/post.entity';
+import { Post } from '../../entity/post.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { PostType } from 'src/enum/postType.enum';
+import { PostType } from '../../enum/postType.enum';
 import { StatisticsDTO } from '../statistics/dto/statistics.dto';
 import { HttpService } from '@nestjs/axios';
 import { catchError, firstValueFrom } from 'rxjs';
@@ -285,7 +285,7 @@ export class PostService {
 
     for (const [key, value] of Object.entries(dateTimeMap)) {
       const [date, time] = key.split('T');
-      const [hour, _] = time.split(':');
+      const hour = time.split(':')[0];
       if (!formattedResults[date]) {
         formattedResults[date] = {};
       }

--- a/test/unit/controller/statistics.controller.spec.ts
+++ b/test/unit/controller/statistics.controller.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatisticsController } from '../../../src/feature/statistics/statistics.controller';
+import { StatisticsService } from '../../../src/feature/statistics/statistics.service';
+import { StatisticsDTO } from '../../../src/feature/statistics/dto/statistics.dto';
+
+describe('StatisticsController', () => {
+  let statisticsController: StatisticsController;
+  let statisticsService: StatisticsService;
+
+  const mockStatisticsService = {
+    getStatisticsByDate: jest.fn(),
+    getStatisticsByHour: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StatisticsController],
+      providers: [
+        {
+          provide: StatisticsService,
+          useValue: mockStatisticsService,
+        },
+      ],
+    }).compile();
+
+    statisticsService = module.get<StatisticsService>(StatisticsService);
+    statisticsController =
+      module.get<StatisticsController>(StatisticsController);
+  });
+
+  it('should be defined', () => {
+    expect(statisticsController).toBeDefined();
+  });
+
+  describe('getStatistics', () => {
+    const req = {
+      id: 'exampleId',
+      username: 'exampleUsername',
+      email: 'exampleEmail',
+    };
+
+    it('should return statistics by date when type is "date" and hashtag is provided', () => {
+      const statisticsDTO: StatisticsDTO = {
+        hashtag: 'test',
+        type: 'date',
+        start: '2021-01-01',
+        end: '2021-01-31',
+      };
+
+      const expectedResult = {
+        '2023-09-02': 0,
+        '2023-09-03': 0,
+        '2023-09-04': 0,
+      };
+
+      const getStatisticsByDateSpy = jest
+        .spyOn(statisticsService, 'getStatisticsByDate')
+        .mockResolvedValue(expectedResult);
+
+      const result = statisticsController.getStatistics(statisticsDTO, req);
+
+      expect(getStatisticsByDateSpy).toHaveBeenCalledWith(statisticsDTO);
+      expect(result).resolves.toEqual(expectedResult);
+    });
+
+    it('should return statistics by hour when type is "hour" and hashtag is provided', () => {
+      const statisticsDTO: StatisticsDTO = {
+        hashtag: 'test',
+        type: 'hour',
+        start: '2021-01-01T00:00:00Z',
+        end: '2021-01-01T23:59:59Z',
+      };
+
+      const expectedResult = {
+        '2023-10-25': {
+          '1': 0,
+          '2': 0,
+          '3': 0,
+        },
+      };
+
+      const getStatisticsByHourSpy = jest
+        .spyOn(statisticsService, 'getStatisticsByHour')
+        .mockResolvedValue(expectedResult);
+
+      const result = statisticsController.getStatistics(statisticsDTO, req);
+
+      expect(getStatisticsByHourSpy).toHaveBeenCalledWith(statisticsDTO);
+      expect(result).resolves.toEqual(expectedResult);
+    });
+  });
+});

--- a/test/unit/service/post.lib.spec.ts
+++ b/test/unit/service/post.lib.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostLib } from '../../../src/feature/post/post.lib';
+import { PostService } from '../../../src/feature/post/post.service';
+import { StatisticsDTO } from '../../../src/feature/statistics/dto/statistics.dto';
+import { StatisticsValueType } from '../../../src/enum/statisticsValueType.enum';
+
+describe('PostLib', () => {
+  let postLib: PostLib;
+  let postService: PostService;
+
+  const mockPostService = {
+    getStatisticsByDate: jest.fn(),
+    getStatisticsByHour: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostLib,
+        {
+          provide: PostService,
+          useValue: mockPostService,
+        },
+      ],
+    }).compile();
+
+    postLib = module.get<PostLib>(PostLib);
+    postService = module.get<PostService>(PostService);
+  });
+
+  it('should be defined', () => {
+    expect(postLib).toBeDefined();
+  });
+
+  describe('getStatisticsByDate', () => {
+    it('should call postService.getStatisticsByDate with provided values', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        hashtag: 'tag',
+        value: StatisticsValueType.COUNT,
+        type: 'date',
+        start: '2023-01-01',
+        end: '2023-01-31',
+      };
+
+      const getStatisticsByDateSpy = jest.spyOn(
+        postService,
+        'getStatisticsByDate',
+      );
+
+      await postLib.getStatisticsByDate(statisticsDTO);
+
+      expect(getStatisticsByDateSpy).toHaveBeenCalledWith(statisticsDTO);
+    });
+  });
+
+  describe('getStatisticsByHour', () => {
+    it('should call postService.getStatisticsByHour with provided values', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        hashtag: 'tag',
+        value: StatisticsValueType.COUNT,
+        type: 'hour',
+        start: '2023-01-01T00:00:00Z',
+        end: '2023-01-01T23:59:59Z',
+      };
+
+      const getStatisticsByHourSpy = jest.spyOn(
+        postService,
+        'getStatisticsByHour',
+      );
+
+      await postLib.getStatisticsByHour(statisticsDTO);
+
+      expect(getStatisticsByHourSpy).toHaveBeenCalledWith(statisticsDTO);
+    });
+  });
+});

--- a/test/unit/service/post.statistics.service.spec.ts
+++ b/test/unit/service/post.statistics.service.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostService } from '../../../src/feature/post/post.service';
+import { UnprocessableEntityException } from '@nestjs/common';
+import { StatisticsDTO } from '../../../src/feature/statistics/dto/statistics.dto';
+import { StatisticsValueType } from '../../../src/enum/statisticsValueType.enum';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Post } from '../../../src/entity/post.entity';
+import { HttpService } from '@nestjs/axios';
+import { Repository } from 'typeorm';
+
+class MockRepository {
+  queryBuilder = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockReturnValue([]),
+  };
+
+  createQueryBuilder() {
+    return this.queryBuilder;
+  }
+}
+
+class MockHttpService {}
+
+describe('PostService', () => {
+  let postService: PostService;
+  let postRepository: Repository<Post>;
+  let httpService: HttpService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostService,
+        {
+          provide: getRepositoryToken(Post),
+          useClass: MockRepository,
+        },
+        {
+          provide: HttpService,
+          useClass: MockHttpService,
+        },
+      ],
+    }).compile();
+
+    postService = module.get<PostService>(PostService);
+    postRepository = module.get<Repository<any>>(getRepositoryToken(Post));
+    httpService = module.get<HttpService>(HttpService);
+  });
+
+  it('should be defined', () => {
+    expect(postService).toBeDefined();
+  });
+
+  describe('getStatisticsByDate', () => {
+    it('should return statistics by date for valid date range', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        type: 'date',
+        hashtag: 'exampleHashtag',
+        value: StatisticsValueType.COUNT,
+        start: '2023-09-02',
+        end: '2023-09-04',
+      };
+
+      const result = await postService.getStatisticsByDate(statisticsDTO);
+
+      const expectedResult = {
+        '2023-09-02': 0,
+        '2023-09-03': 0,
+        '2023-09-04': 0,
+      };
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should throw UnprocessableEntityException for date range exceeding 30 days', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        type: 'date',
+        hashtag: 'exampleHashtag',
+        value: StatisticsValueType.COUNT,
+        start: '2023-01-01',
+        end: '2023-02-01',
+      };
+
+      await expect(
+        postService.getStatisticsByDate(statisticsDTO),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+
+  describe('getStatisticsByHour', () => {
+    it('should return statistics by hour for valid time range', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        type: 'hour',
+        hashtag: 'exampleHashtag',
+        value: StatisticsValueType.COUNT,
+        start: '2023-10-25T01:00:00Z',
+        end: '2023-10-25T03:59:59Z',
+      };
+
+      const result = await postService.getStatisticsByHour(statisticsDTO);
+
+      const expectedResult = {
+        '2023-10-25': {
+          '1': 0,
+          '2': 0,
+          '3': 0,
+        },
+      };
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should throw UnprocessableEntityException for time range exceeding 1 week', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        type: 'hour',
+        hashtag: 'exampleHashtag',
+        value: StatisticsValueType.COUNT,
+        start: '2023-01-01T00:00:00Z',
+        end: '2023-01-09T00:00:00Z',
+      };
+
+      await expect(
+        postService.getStatisticsByHour(statisticsDTO),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+});

--- a/test/unit/service/statistics.service.spec.ts
+++ b/test/unit/service/statistics.service.spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatisticsService } from '../../../src/feature/statistics/statistics.service';
+import { PostLib } from '../../../src/feature/post/post.lib';
+import { StatisticsDTO } from '../../../src/feature/statistics/dto/statistics.dto';
+import { StatisticsValueType } from '../../../src/enum/statisticsValueType.enum';
+
+describe('StatisticsService', () => {
+  let statisticsService: StatisticsService;
+  let postLib: PostLib;
+
+  const mockPostLib = {
+    getStatisticsByDate: jest.fn(),
+    getStatisticsByHour: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StatisticsService,
+        {
+          provide: PostLib,
+          useValue: mockPostLib,
+        },
+      ],
+    }).compile();
+
+    statisticsService = module.get<StatisticsService>(StatisticsService);
+    postLib = module.get<PostLib>(PostLib);
+  });
+
+  it('should be defined', () => {
+    expect(statisticsService).toBeDefined();
+  });
+
+  describe('getStatisticsByDate', () => {
+    it('should call postLib.getStatisticsByDate with default values when not provided', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        type: 'date',
+      };
+
+      const setDefaultValueSpy = jest.spyOn(
+        statisticsService,
+        'setDefaultValue',
+      );
+      const getStatisticsByDateSpy = jest.spyOn(postLib, 'getStatisticsByDate');
+
+      await statisticsService.getStatisticsByDate(statisticsDTO);
+
+      expect(setDefaultValueSpy).toHaveBeenCalledWith(statisticsDTO);
+      expect(getStatisticsByDateSpy).toHaveBeenCalledWith(statisticsDTO);
+    });
+
+    it('should call postLib.getStatisticsByDate with provided values', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        hashtag: 'tag',
+        value: StatisticsValueType.COUNT,
+        type: 'date',
+        start: '2023-01-01',
+        end: '2023-01-31',
+      };
+
+      const setDefaultValueSpy = jest.spyOn(
+        statisticsService,
+        'setDefaultValue',
+      );
+      const getStatisticsByDateSpy = jest.spyOn(postLib, 'getStatisticsByDate');
+
+      await statisticsService.getStatisticsByDate(statisticsDTO);
+
+      expect(setDefaultValueSpy).toHaveBeenCalledWith(statisticsDTO);
+      expect(getStatisticsByDateSpy).toHaveBeenCalledWith(statisticsDTO);
+    });
+  });
+
+  describe('getStatisticsByHour', () => {
+    it('should call postLib.getStatisticsByHour with default values when not provided', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        type: 'hour',
+      };
+
+      const setDefaultValueSpy = jest.spyOn(
+        statisticsService,
+        'setDefaultValue',
+      );
+      const getStatisticsByHourSpy = jest.spyOn(postLib, 'getStatisticsByHour');
+
+      await statisticsService.getStatisticsByHour(statisticsDTO);
+
+      expect(setDefaultValueSpy).toHaveBeenCalledWith(statisticsDTO);
+      expect(getStatisticsByHourSpy).toHaveBeenCalledWith(statisticsDTO);
+    });
+
+    it('should call postLib.getStatisticsByHour with provided values', async () => {
+      const statisticsDTO: StatisticsDTO = {
+        hashtag: 'tag',
+        value: StatisticsValueType.COUNT,
+        type: 'hour',
+        start: '2023-01-01T00:00:00Z',
+        end: '2023-01-01T23:59:59Z',
+      };
+
+      const setDefaultValueSpy = jest.spyOn(
+        statisticsService,
+        'setDefaultValue',
+      );
+      const getStatisticsByHourSpy = jest.spyOn(postLib, 'getStatisticsByHour');
+
+      await statisticsService.getStatisticsByHour(statisticsDTO);
+
+      expect(setDefaultValueSpy).toHaveBeenCalledWith(statisticsDTO);
+      expect(getStatisticsByHourSpy).toHaveBeenCalledWith(statisticsDTO);
+    });
+  });
+});


### PR DESCRIPTION
## 🚀 이슈 번호
#25 통계 Unit Test
<br>

## 💡 변경 이유
<br>

## 🔑 주요 변경사항
- statistics.controller, statistics.service, post.Lib, post.service(통계 관련 코드만) 테스트 코드 작성
- 은수님과 동훈님 테스트 코드 바탕으로 작업.
	- spy.On을 원래 최대한 피하는 쪽으로 늘 테스트 코드를 짰었는데, spyOn을 쓰니 원래 코드의 함수를 직접 갖다 쓸 수 있다는 점이 편했고 또한 chat gpt가 (너무너무)사랑하는 spyOn을 써도 된다는 사실이 좋았습니다.
<br>

## 📷 테스트 결과
